### PR TITLE
Allow HTTP version to be set on an Easy object.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -68,6 +68,7 @@ fn main() {
 
     let openssl_root = register_dep("OPENSSL");
     let zlib_root = register_dep("Z");
+    let nghttp2_root = register_dep("NGHTTP2");
 
     let cfg = gcc::Config::new();
     let compiler = cfg.get_compiler();
@@ -146,10 +147,15 @@ fn main() {
         cmd.arg(format!("--target={}", target));
     }
 
+    if let Some(root) = nghttp2_root {
+        cmd.arg(format!("--with-nghttp2={}", msys_compatible(&root)));
+    } else {
+        cmd.arg("--without-nghttp2");
+    }
+
     cmd.arg("--without-librtmp");
     cmd.arg("--without-libidn");
     cmd.arg("--without-libssh2");
-    cmd.arg("--without-nghttp2");
     cmd.arg("--disable-ldap");
     cmd.arg("--disable-ldaps");
     cmd.arg("--disable-ftp");

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -605,6 +605,22 @@ pub const CURL_IPRESOLVE_WHATEVER: c_int = 0;
 pub const CURL_IPRESOLVE_V4: c_int = 1;
 pub const CURL_IPRESOLVE_V6: c_int = 2;
 
+/// These enums are for use with the CURLOPT_HTTP_VERSION option.
+pub type curl_HttpVersion = __enum_ty;
+/// Setting this means we don't care, and that we'd like the library to choose 
+/// the best possible for us!
+pub const CURL_HTTP_VERSION_NONE: curl_HttpVersion = 0;
+/// Please use HTTP 1.0 in the request
+pub const CURL_HTTP_VERSION_1_0: curl_HttpVersion = 1;
+/// Please use HTTP 1.1 in the request
+pub const CURL_HTTP_VERSION_1_1: curl_HttpVersion = 2;
+/// Please use HTTP 2 in the request
+pub const CURL_HTTP_VERSION_2_0: curl_HttpVersion = 3;
+/// Use version 2 for HTTPS, version 1.1 for HTTP
+pub const CURL_HTTP_VERSION_2TLS: curl_HttpVersion = 4;
+/// Please use HTTP 2 without HTTP/1.1 Upgrade
+pub const CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE: curl_HttpVersion = 5;
+
 // Note that the type here is wrong, it's just intended to just be an enum.
 pub const CURL_SSLVERSION_DEFAULT: CURLoption = 0;
 pub const CURL_SSLVERSION_TLSv1: CURLoption = 1;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -203,6 +203,33 @@ pub enum IpResolve {
     __Nonexhaustive = 500,
 }
 
+/// Possible values to pass to the `http_version` method.
+pub enum HttpVersion {
+    /// We don't care what http version to use, and we'd like the library to 
+    /// choose the best possible for us.
+    Any = curl_sys::CURL_HTTP_VERSION_NONE as isize,
+
+    /// Please use HTTP 1.0 in the request
+    V10 = curl_sys::CURL_HTTP_VERSION_1_0 as isize,
+
+    /// Please use HTTP 1.1 in the request
+    V11 = curl_sys::CURL_HTTP_VERSION_1_1 as isize,
+
+    /// Please use HTTP 2 in the request
+    V2 = curl_sys::CURL_HTTP_VERSION_2_0 as isize,
+
+    /// Use version 2 for HTTPS, version 1.1 for HTTP
+    V2TLS = curl_sys::CURL_HTTP_VERSION_2TLS as isize,
+
+    /// Please use HTTP 2 without HTTP/1.1 Upgrade
+    V2PriorKnowledge = curl_sys::CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE as isize,
+
+    /// Hidden variant to indicate that this enum should not be matched on, it
+    /// may grow over time.
+    #[doc(hidden)]
+    __Nonexhaustive = 500,
+}
+
 /// Possible values to pass to the `ip_resolve` method.
 #[allow(missing_docs)]
 pub enum SslVersion {
@@ -1965,6 +1992,14 @@ impl Easy {
     // pub fn ssl_false_start(&mut self, enable: bool) -> Result<(), Error> {
     //     self.setopt_long(curl_sys::CURLOPT_SSLENGINE_DEFAULT, enable as c_long)
     // }
+
+    /// Set preferred HTTP version.
+    ///
+    /// By default this option is not set and corresponds to
+    /// `CURLOPT_HTTP_VERSION`.
+    pub fn http_version(&mut self, version: HttpVersion) -> Result<(), Error> {
+        self.setopt_long(curl_sys::CURLOPT_HTTP_VERSION, version as c_long)
+    }
 
     /// Set preferred TLS/SSL version.
     ///


### PR DESCRIPTION
Allow linking to nghttp2 when compiling from scratch.